### PR TITLE
Benchmark Updates

### DIFF
--- a/psbench/benchmarks/endpoint_qps/main.py
+++ b/psbench/benchmarks/endpoint_qps/main.py
@@ -9,6 +9,7 @@ import multiprocessing
 import sys
 import time
 from typing import Callable
+from typing import NamedTuple
 from typing import Sequence
 
 if sys.version_info >= (3, 8):  # pragma: >3.7 cover
@@ -20,23 +21,42 @@ from proxystore.store.endpoint import EndpointStore
 
 from psbench.argparse import add_logging_options
 from psbench.benchmarks.endpoint_qps import routes
+from psbench.csv import CSVLogger
 from psbench.logging import init_logging
 from psbench.logging import TESTING_LOG_LEVEL
 
 PROCESS_STARTUP_BUFFER_SECONDS = 5
+ROUTE_TYPE = Literal['GET', 'SET', 'EXISTS', 'EVICT', 'ENDPOINT']
 
 logger = logging.getLogger('endpoint-qps')
 
 
+class RunStats(NamedTuple):
+    """Stats for the run."""
+
+    route: ROUTE_TYPE
+    payload_size_bytes: int
+    queries_per_worker: int
+    sleep_seconds: float
+    workers: int
+    min_worker_elapsed_time_ms: float
+    max_worker_elapsed_time_ms: float
+    avg_worker_elapsed_time_ms: float
+    min_latency_ms: float
+    max_latency_ms: float
+    avg_latency_ms: float
+    qps: float
+
+
 def runner(
     endpoint: str,
-    route: Literal['GET', 'SET', 'EXISTS', 'EVICT', 'ENDPOINT'],
+    route: ROUTE_TYPE,
     *,
     payload_size: int = 0,
     queries: int = 100,
     sleep: float = 0,
     workers: int = 1,
-) -> None:
+) -> RunStats:
     """Run test workers and gather results.
 
     Args:
@@ -46,6 +66,9 @@ def runner(
         queries (int): number of queries to perform per worker.
         sleep (float): sleep (seconds) between queries.
         workers (int): number of worker processes to use.
+
+    Returns:
+        RunStats with summary of test run.
     """
     store = EndpointStore('store', endpoints=[endpoint], cache_size=0)
 
@@ -102,10 +125,26 @@ def runner(
 
     min_elapsed_ms = min(s.total_elapsed_ms for s in stats)
     max_elapsed_ms = max(s.total_elapsed_ms for s in stats)
+    avg_elapsed_ms = sum(s.total_elapsed_ms for s in stats) / len(stats)
     min_latency_ms = min(s.min_latency_ms for s in stats)
     max_latency_ms = max(s.max_latency_ms for s in stats)
     avg_latency_ms = sum(s.avg_latency_ms for s in stats) / len(stats)
     queries = sum(s.queries for s in stats)
+
+    run_stats = RunStats(
+        route=route,
+        payload_size_bytes=payload_size,
+        queries_per_worker=queries,
+        sleep_seconds=sleep,
+        workers=workers,
+        min_worker_elapsed_time_ms=min_elapsed_ms,
+        max_worker_elapsed_time_ms=max_elapsed_ms,
+        avg_worker_elapsed_time_ms=avg_elapsed_ms,
+        min_latency_ms=min_latency_ms,
+        max_latency_ms=max_latency_ms,
+        avg_latency_ms=avg_latency_ms,
+        qps=queries / (max_elapsed_ms / 1000),
+    )
 
     logger.log(
         TESTING_LOG_LEVEL,
@@ -115,8 +154,10 @@ def runner(
         f'minimum request latency: {min_latency_ms:.3f} ms\n'
         f'maximum request latency: {max_latency_ms:.3f} ms\n'
         f'average request latency: {avg_latency_ms:.3f} ms\n'
-        f'total QPS: {queries / (min_elapsed_ms / 1000):.3f}',
+        f'total QPS: {run_stats.qps:.3f}',
     )
+
+    return run_stats
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -166,7 +207,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     init_logging(args.log_file, args.log_level, force=True)
 
-    runner(
+    run_stats = runner(
         args.endpoint,
         args.route,
         payload_size=args.payload_size,
@@ -174,5 +215,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         sleep=args.sleep,
         workers=args.workers,
     )
+
+    if args.csv_file is not None:
+        csv_logger = CSVLogger(args.csv_file, RunStats)
+        csv_logger.log(run_stats)
+        csv_logger.close()
+
+        logger.log(TESTING_LOG_LEVEL, f'results logged to {args.csv_file}')
 
     return 0

--- a/psbench/benchmarks/endpoint_qps/routes.py
+++ b/psbench/benchmarks/endpoint_qps/routes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import time
 import uuid
+from statistics import stdev
 from typing import NamedTuple
 
 import requests
@@ -19,6 +20,7 @@ class Stats(NamedTuple):
     min_latency_ms: float
     max_latency_ms: float
     avg_latency_ms: float
+    stdev_latency_ms: float
 
 
 def endpoint_test(
@@ -64,6 +66,7 @@ def endpoint_test(
         min_latency_ms=min(latencies),
         max_latency_ms=max(latencies),
         avg_latency_ms=sum(latencies) / len(latencies),
+        stdev_latency_ms=stdev(latencies) if len(latencies) > 1 else 0,
     )
 
 
@@ -104,6 +107,7 @@ def evict_test(
         min_latency_ms=min(latencies),
         max_latency_ms=max(latencies),
         avg_latency_ms=sum(latencies) / len(latencies),
+        stdev_latency_ms=stdev(latencies) if len(latencies) > 1 else 0,
     )
 
 
@@ -144,6 +148,7 @@ def exists_test(
         min_latency_ms=min(latencies),
         max_latency_ms=max(latencies),
         avg_latency_ms=sum(latencies) / len(latencies),
+        stdev_latency_ms=stdev(latencies) if len(latencies) > 1 else 0,
     )
 
 
@@ -190,6 +195,7 @@ def get_test(
         min_latency_ms=min(latencies),
         max_latency_ms=max(latencies),
         avg_latency_ms=sum(latencies) / len(latencies),
+        stdev_latency_ms=stdev(latencies) if len(latencies) > 1 else 0,
     )
 
 
@@ -240,4 +246,5 @@ def set_test(
         min_latency_ms=min(latencies),
         max_latency_ms=max(latencies),
         avg_latency_ms=sum(latencies) / len(latencies),
+        stdev_latency_ms=stdev(latencies) if len(latencies) > 1 else 0,
     )

--- a/psbench/proxystore.py
+++ b/psbench/proxystore.py
@@ -29,19 +29,18 @@ def init_store_from_args(
         Store or None if no store was specified.
     """
     store: Store | None = None
-    name = 'default-store'
 
     if args.ps_backend == STORES.ENDPOINT.name:
         store = init_store(
             STORES.ENDPOINT,
-            name=name,
+            name='endpoint-store',
             endpoints=args.ps_endpoints,
             **kwargs,
         )
     elif args.ps_backend == STORES.FILE.name:
         store = init_store(
             STORES.FILE,
-            name=name,
+            name='file-store',
             store_dir=args.ps_file_dir,
             **kwargs,
         )
@@ -49,14 +48,14 @@ def init_store_from_args(
         endpoints = GlobusEndpoints.from_json(args.ps_globus_config)
         store = init_store(
             STORES.GLOBUS,
-            name=name,
+            name='globus-store',
             endpoints=endpoints,
             **kwargs,
         )
     elif args.ps_backend == STORES.REDIS.name:
         store = init_store(
             STORES.REDIS,
-            name=name,
+            name='redis-store',
             hostname=args.ps_redis_host,
             port=args.ps_redis_port,
             **kwargs,

--- a/psbench/utils.py
+++ b/psbench/utils.py
@@ -18,7 +18,7 @@ def randbytes(size: int) -> bytes:
     Returns:
         random byte string.
     """
-    if sys.version_info >= (3, 9):  # pragma: >=3.9 cover
+    if sys.version_info >= (3, 9) and size < 1e9:  # pragma: >=3.9 cover
         return random.randbytes(size)
     else:  # pragma: <3.9 cover
         return os.urandom(size)

--- a/tests/benchmarks/endpoint_qps/main_test.py
+++ b/tests/benchmarks/endpoint_qps/main_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+import tempfile
 from unittest import mock
 
 if sys.version_info >= (3, 8):  # pragma: >3.7 cover
@@ -12,6 +13,7 @@ import pytest
 
 from psbench.benchmarks.endpoint_qps.main import main
 from psbench.benchmarks.endpoint_qps.main import runner
+from psbench.benchmarks.endpoint_qps.main import RunStats
 from psbench.benchmarks.endpoint_qps.routes import Stats
 
 
@@ -36,3 +38,26 @@ def test_runner(
 @mock.patch('psbench.benchmarks.endpoint_qps.main.runner')
 def test_main(mock_runner) -> None:
     assert main(['UUID', '--route', 'GET']) == 0
+
+
+@mock.patch('psbench.benchmarks.endpoint_qps.main.runner')
+def test_csv_logging(mock_runner) -> None:
+    mock_runner.return_value = RunStats(
+        route='GET',
+        payload_size_bytes=0,
+        queries_per_worker=1,
+        sleep_seconds=0.0,
+        workers=1,
+        min_worker_elapsed_time_ms=1,
+        max_worker_elapsed_time_ms=1,
+        avg_worker_elapsed_time_ms=1,
+        min_latency_ms=1,
+        max_latency_ms=1,
+        avg_latency_ms=1,
+        qps=1,
+    )
+
+    with tempfile.NamedTemporaryFile() as f:
+        assert len(f.readlines()) == 0
+        assert main(['UUID', '--route', 'GET', '--csv-file', f.name]) == 0
+        assert len(f.readlines()) == 2

--- a/tests/benchmarks/endpoint_qps/main_test.py
+++ b/tests/benchmarks/endpoint_qps/main_test.py
@@ -26,7 +26,9 @@ def test_runner(
 ) -> None:
     def call_directly(func, *args, **kwargs):
         result = mock.MagicMock()
-        result.get = mock.MagicMock(return_value=Stats(2, 0.1, 0.1, 0.1, 0.1))
+        result.get = mock.MagicMock(
+            return_value=Stats(2, 0.1, 0.1, 0.1, 0.1, 0.1),
+        )
         return result
 
     with mock.patch(
@@ -45,15 +47,17 @@ def test_csv_logging(mock_runner) -> None:
     mock_runner.return_value = RunStats(
         route='GET',
         payload_size_bytes=0,
-        queries_per_worker=1,
+        total_queries=1,
         sleep_seconds=0.0,
         workers=1,
         min_worker_elapsed_time_ms=1,
         max_worker_elapsed_time_ms=1,
         avg_worker_elapsed_time_ms=1,
+        stdev_worker_elapsed_time_ms=1,
         min_latency_ms=1,
         max_latency_ms=1,
         avg_latency_ms=1,
+        stdev_latency_ms=1,
         qps=1,
     )
 

--- a/tests/benchmarks/endpoint_qps/main_test.py
+++ b/tests/benchmarks/endpoint_qps/main_test.py
@@ -12,29 +12,45 @@ else:  # pragma: <3.8 cover
 import pytest
 
 from psbench.benchmarks.endpoint_qps.main import main
+from psbench.benchmarks.endpoint_qps.main import run
 from psbench.benchmarks.endpoint_qps.main import runner
 from psbench.benchmarks.endpoint_qps.main import RunStats
 from psbench.benchmarks.endpoint_qps.routes import Stats
+
+
+def call_directly(func, *args, **kwargs):
+    result = mock.MagicMock()
+    result.get = mock.MagicMock(
+        return_value=Stats(2, 0.1, 0.1, 0.1, 0.1, 0.1),
+    )
+    return result
 
 
 @pytest.mark.parametrize(
     'route',
     ('GET', 'SET', 'EXISTS', 'EVICT', 'ENDPOINT'),
 )
-def test_runner(
+def test_run(
     route: Literal['GET', 'SET', 'EXISTS', 'EVICT', 'ENDPOINT'],
 ) -> None:
-    def call_directly(func, *args, **kwargs):
-        result = mock.MagicMock()
-        result.get = mock.MagicMock(
-            return_value=Stats(2, 0.1, 0.1, 0.1, 0.1, 0.1),
-        )
-        return result
-
     with mock.patch(
         'psbench.benchmarks.endpoint_qps.main.EndpointStore',
     ), mock.patch('multiprocessing.pool.Pool.apply_async', new=call_directly):
-        runner('UUID', route, payload_size=1, queries=2, sleep=0, workers=2)
+        run('UUID', route, payload_size=1, queries=2, sleep=0, workers=2)
+
+
+def test_runner() -> None:
+    with mock.patch(
+        'psbench.benchmarks.endpoint_qps.main.EndpointStore',
+    ), mock.patch('multiprocessing.pool.Pool.apply_async', new=call_directly):
+        runner(
+            'UUID',
+            ['ENDPOINT'],
+            payload_sizes=[0],
+            queries=1,
+            sleeps=[0],
+            workers=[1],
+        )
 
 
 @mock.patch('psbench.benchmarks.endpoint_qps.main.runner')
@@ -42,9 +58,9 @@ def test_main(mock_runner) -> None:
     assert main(['UUID', '--route', 'GET']) == 0
 
 
-@mock.patch('psbench.benchmarks.endpoint_qps.main.runner')
-def test_csv_logging(mock_runner) -> None:
-    mock_runner.return_value = RunStats(
+@mock.patch('psbench.benchmarks.endpoint_qps.main.run')
+def test_csv_logging(mock_run) -> None:
+    mock_run.return_value = RunStats(
         route='GET',
         payload_size_bytes=0,
         total_queries=1,
@@ -63,5 +79,13 @@ def test_csv_logging(mock_runner) -> None:
 
     with tempfile.NamedTemporaryFile() as f:
         assert len(f.readlines()) == 0
-        assert main(['UUID', '--route', 'GET', '--csv-file', f.name]) == 0
-        assert len(f.readlines()) == 2
+        runner(
+            'UUID',
+            ['GET', 'SET'],
+            payload_sizes=[0, 1, 2],
+            queries=1,
+            sleeps=[0, 1, 2, 3, 4],
+            workers=[0, 1, 2, 3, 4, 5, 6],
+            csv_file=f.name,
+        )
+        assert len(f.readlines()) == 1 + (2 * 3 * 5 * 7)


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Lots of minor updates to the existing benchmarks.

- FuncX roundtrip benchmark now asynchronously resolves proxies during the task sleep. This is to simulate overlapping computation and communication.
- Fixed `randbytes()` not working with very large sizes (> 100 MB).
- Fixed clash between store names on FuncX workers that persist across benchmark runs.
- Added standard deviations and CSV logging to the endpoint QPS benchmark.
- QPS benchmark can now run a matrix of benchmark parameters (#13).

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #13

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)

## Testing
<!--- Please describe the test ran to verify changes --->

Tests pass. Ran benchmarks individually to verify it all works.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
