### PR TITLE
Update FuncX to >=1.0.3 (#17)

### DIFF
--- a/psbench/benchmarks/funcx_tasks/main.py
+++ b/psbench/benchmarks/funcx_tasks/main.py
@@ -26,21 +26,11 @@ from psbench.logging import init_logging
 from psbench.logging import TESTING_LOG_LEVEL
 from psbench.proxystore import init_store_from_args
 from psbench.tasks.pong import pong
+from psbench.tasks.pong import pong_proxy
 from psbench.utils import randbytes
 
+
 logger = logging.getLogger('funcx-test')
-
-
-def pong_proxy(*args, **kwargs):  # type: ignore
-    """Trampoline function for psbench.tasks.pong.pong_proxy.
-
-    The trampoline is needed to remove type annotations since there is an
-    issue in FuncX with serializing functions with type annotations.
-    (See FuncX #901)
-    """
-    from psbench.tasks.pong import pong_proxy as _pong_proxy
-
-    return _pong_proxy(*args, **kwargs)
 
 
 @dataclasses.dataclass

--- a/psbench/tasks/pong.py
+++ b/psbench/tasks/pong.py
@@ -62,6 +62,7 @@ def pong_proxy(
     from proxystore.store import get_store
     from proxystore.store import UnknownStoreError
 
+    from psbench.tasks.pong import ProxyStats
     from psbench.utils import randbytes
 
     assert isinstance(data, bytes) and isinstance(data, Proxy)

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,8 +18,8 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    funcx==1.0.*
-    funcx-endpoint==1.0.*
+    funcx>=1.0.3
+    funcx-endpoint>=1.0.3
     proxystore[endpoints]==0.4.0a2
     requests
 python_requires = >=3.7


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Updates funcX to >=1.0.3 which removes the need for the serialization hack with a trampoline function in `pong_proxy`.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #17

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)

## Testing
<!--- Please describe the test ran to verify changes --->

All test pass. Tested the funcX benchmark as well.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Code changes pass `pre-commit` (e.g., black, flake8, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
